### PR TITLE
수정: 포트 url로 들어가면 바로 로그인 화면 뜨게 구축

### DIFF
--- a/chat_project/chat_project/urls.py
+++ b/chat_project/chat_project/urls.py
@@ -17,9 +17,12 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import path, include
+from accounts import views
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("chatbot/", include("chatbot.urls")), 
     path("accounts/", include("accounts.urls")),
+    path('', views.user_login, name='root-login'),  # 루트에서 바로 로그인 화면
 ]


### PR DESCRIPTION
<기존>
포트번호/accounts/login 주소로 들어가야 로그인 화면이 뜬다.

<변경>
포트번호로 바로 들어가면 로그인 화면이 뜬다. 